### PR TITLE
fix: add missing test dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 test-unit:
-	docker run --rm -v `pwd`/..:/var/www devenv_phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Unit Tests"'
+	docker run --rm -v `pwd`/..:/var/www ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Unit Tests"'
 
 test-virtuoso:
-	docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=virtuoso --link devenv_virtuoso-test_1:virtuoso-test devenv_phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
+	docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=virtuoso --link ontowiki-devenv-virtuoso-test:virtuoso-test --net devenv_default ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
 
 test-mysql:
-	docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=zenddb --link devenv_mysql-test_1:mysql-test devenv_phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
+	docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=zenddb --link ontowiki-devenv-mysql-test:mysql-test --net devenv_default ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'

--- a/README.md
+++ b/README.md
@@ -26,23 +26,24 @@ Make sure you are in the root directory of your devenv clone and execute the fol
 
     docker-compose up -d
 
-This will start up the following containers in the background (names may vary):
+This will start up the following containers in the background:
 
-- nginx
-- phpserver
-- virtuoso-dev
-- mysql-dev
-- virtuoso-test
-- mysql-test
+- ontowiki-devenv-nginx
+- ontowiki-devenv-phpserver
+- ontowiki-devenv-mysql-test
+- ontowiki-devenv-mysql-dev
+- ontowiki-devenv-virtuoso-test
+- ontowiki-devenv-virtuoso-dev
+
 
 If you want to inspect the logs of one of the containers execute for example:
 
-    docker logs -f devenv_nginx_1
+    docker logs -f ontowiki-devenv-nginx
 
 If you want to stop all containers enter:
 
     docker-compose stop
-  
+
 If you want to also remove the containers execute the following command instead:
 
     docker-compose down
@@ -52,7 +53,7 @@ If you want to also remove the containers execute the following command instead:
     http://<IP-of-Docker-Host>
     # or if configured in /etc/hosts
     http://ontowiki.local
-    
+
 ## Run Tests
 
 ### Unit tests with bundled PHP
@@ -61,7 +62,7 @@ If you want to also remove the containers execute the following command instead:
 
 or
 
-    docker run --rm -v `pwd`/..:/var/www devenv_phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Unit Tests"'
+    docker run --rm -v `pwd`/..:/var/www ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Unit Tests"'
 
 ### Unit tests with other PHP versions
 
@@ -93,7 +94,7 @@ or
 
 or
 
-    docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=virtuoso --link devenv_virtuoso-test_1:virtuoso-test devenv_phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
+    docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=virtuoso --link ontowiki-devenv-virtuoso-test:virtuoso-test --net devenv_default ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
 
 ### Integration tests with MySQL
 
@@ -101,8 +102,8 @@ or
 
 or
 
-    docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=zenddb --link devenv_mysql-test_1:mysql-test devenv_phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
-    
+    docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=zenddb --link ontowiki-devenv-mysql-test:mysql-test --net devenv_default ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
+
 ## Tips & Tricks
 
 ### Use `docker-machine` (e.g. on a Mac)
@@ -160,4 +161,3 @@ Build the custom image (provides nginx configuration for OntoWiki):
 Run a container based on that image:
 
     docker run -d --name nginx --link phpserver:phpserver -v `pwd`/..:/var/www -p 80:80 ow_nginx
-    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,62 +1,72 @@
-virtuoso-dev:
-  image: tenforce/virtuoso
-  environment:
-    DBA_PASSWORD: owdev
-    SPARQL_UPDATE: "true"
-  volumes:
-    - /data
-  ports:
-    - "8890:8890"
-    - "1111:1111"
+version: '2'
+services:
+  virtuoso-dev:
+    image: tenforce/virtuoso
+    container_name: ontowiki-devenv-virtuoso-dev
+    environment:
+      DBA_PASSWORD: owdev
+      SPARQL_UPDATE: "true"
+    volumes:
+      - /data
+    ports:
+      - "8890:8890"
+      - "1111:1111"
 
-virtuoso-test:
-  image: tenforce/virtuoso
-  environment:
-    DBA_PASSWORD: owdev
-    SPARQL_UPDATE: "true"
-  volumes:
-    - /data
-  ports:
-    - "8891:8890"
-    - "1112:1111"
+  virtuoso-test:
+    image: tenforce/virtuoso
+    container_name: ontowiki-devenv-virtuoso-test
+    environment:
+      DBA_PASSWORD: owdev
+      SPARQL_UPDATE: "true"
+    volumes:
+      - /data
+    ports:
+      - "8891:8890"
+      - "1112:1111"
 
-mysql-dev:
-  image: mysql
-  environment:
-    MYSQL_RANDOM_ROOT_PASSWORD: 1
-    MYSQL_USER: php
-    MYSQL_PASSWORD: owdev
-    MYSQL_DATABASE: ontowiki-dev
-  volumes:
-    - /var/lib/mysql
-  ports:
-    - "3306:3306"
+  mysql-dev:
+    image: mysql
+    container_name: ontowiki-devenv-mysql-dev
+    environment:
+      MYSQL_RANDOM_ROOT_PASSWORD: 1
+      MYSQL_USER: php
+      MYSQL_PASSWORD: owdev
+      MYSQL_DATABASE: ontowiki-dev
+    volumes:
+      - /var/lib/mysql
+    ports:
+      - "3306:3306"
 
-mysql-test:
-  image: mysql
-  environment:
-    MYSQL_RANDOM_ROOT_PASSWORD: 1
-    MYSQL_USER: php
-    MYSQL_PASSWORD: owdev
-    MYSQL_DATABASE: ow_TEST
-  volumes:
-    - /var/lib/mysql
-  ports:
-    - "3307:3306"
+  mysql-test:
+    image: mysql
+    container_name: ontowiki-devenv-mysql-test
+    environment:
+      MYSQL_RANDOM_ROOT_PASSWORD: 1
+      MYSQL_USER: php
+      MYSQL_PASSWORD: owdev
+      MYSQL_DATABASE: ow_TEST
+    volumes:
+      - /var/lib/mysql
+    ports:
+      - "3307:3306"
 
-phpserver:
-  build: ./docker/php
-  volumes:
-    - ./..:/var/www
-  links:
-    - virtuoso-dev
-    - mysql-dev
+  phpserver:
+    build: ./docker/php
+    image: ontowiki-devenv/phpserver
+    container_name: ontowiki-devenv-phpserver
+    volumes:
+      - ./..:/var/www
+    links:
+      - virtuoso-dev
+      - mysql-dev
 
-nginx:
-  build: ./docker/nginx
-  volumes:
-    - ./..:/var/www
-  links:
-    - phpserver
-  ports:
-    - "80:80"
+  nginx:
+    build: ./docker/nginx
+    image: ontowiki-devenv/nginx2
+    container_name: ontowiki-devenv-nginx
+    volumes:
+      - ./..:/var/www
+    links:
+      - phpserver
+    ports:
+      - "80:80"

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 
 RUN apt-get update \
- && apt-get install -y libvirtodbc0 \
+ && apt-get install -y libvirtodbc0 raptor-utils \
  && apt-get install -y php5-fpm php5-cli php5-mysql php5-odbc php5-xdebug \
  && apt-get install -y php5-common php5-tidy php5-xsl php5-xmlrpc php5-gd php5-memcache php5-memcached \
  && apt-get clean \


### PR DESCRIPTION
This fixes #2.

- `raptor-utils` are added to php image
- docker compose file is updated to use version 2 format
- compose files specifies names for images and containers
- README is updated to reflect changes
- Makefile is updated to reflect changes