### PR TITLE
Add support for stardog backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@ test-unit:
 	docker run --rm -v `pwd`/..:/var/www ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Unit Tests"'
 
 test-virtuoso:
-	docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=virtuoso --link ontowiki-devenv-virtuoso-test:virtuoso-test --net devenv_default ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
+	docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=virtuoso --net devenv_default ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
 
 test-mysql:
-	docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=zenddb --link ontowiki-devenv-mysql-test:mysql-test --net devenv_default ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
+	docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=zenddb --net devenv_default ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
+
+test-stardog:
+	docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=stardog --net devenv_default ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ or
 
 or
 
-    docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=virtuoso --link ontowiki-devenv-virtuoso-test:virtuoso-test --net devenv_default ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
+    docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=virtuoso --net devenv_default ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
 
 ### Integration tests with MySQL
 
@@ -102,7 +102,15 @@ or
 
 or
 
-    docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=zenddb --link ontowiki-devenv-mysql-test:mysql-test --net devenv_default ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
+    docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=zenddb --net devenv_default ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
+
+### Integration tests with Stardog
+
+    make test-stardog
+
+or
+
+    docker run --rm -v `pwd`/..:/var/www -e EF_STORE_ADAPTER=stardog --net devenv_default ontowiki-devenv/phpserver /bin/sh -c 'cd /var/www && php vendor/bin/phpunit --testsuite "OntoWiki Virtuoso Integration Tests"'
 
 ## Tips & Tricks
 

--- a/config-test.ini.dist
+++ b/config-test.ini.dist
@@ -4,7 +4,7 @@
 ;; Database Connection Settings                                               ;;
 ;;----------------------------------------------------------------------------;;
 
-store.backend = zenddb ; zenddb, virtuoso, multi
+store.backend = test ; zenddb, virtuoso, multi
 
 store.zenddb.dbname   = ow_TEST ; needs to end with _TEST
 store.zenddb.username = php
@@ -15,3 +15,8 @@ store.zenddb.host     = mysql-test ; default is localhost
 store.virtuoso.dsn      = VOS_TEST ; needs to end with _TEST
 store.virtuoso.username = dba
 store.virtuoso.password = owdev
+
+store.stardog.base_url   = "http://stardog-test:5820"
+store.stardog.username   = admin
+store.stardog.password   = admin
+store.stardog.database   = "ow_TEST"

--- a/config.ini.dist
+++ b/config.ini.dist
@@ -42,6 +42,14 @@ store.virtuoso.search_max_length_for_bifcontains = "4"
 ;store.virtuoso.use_persistent_connection = true
 
 ;;;;
+;; Stardog backend specific options
+;;
+store.stardog.base_url   = "http://stardog-dev:5820"
+store.stardog.username   = admin
+store.stardog.password   = admin
+store.stardog.database   = "ontowiki-dev"
+
+;;;;
 ;; ARC2 backend specific options
 ;;
 store.arc.dbname = "ontowiki_arc2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,24 @@ services:
     ports:
       - "3307:3306"
 
+  stardog-dev:
+    image: aksw/dld-store-stardog
+    container_name: ontowiki-devenv-stardog-dev
+    volumes:
+      - /stardog
+    ports:
+      - "5820:5820"
+      - "8080:80"
+
+  stardog-test:
+    image: aksw/dld-store-stardog
+    container_name: ontowiki-devenv-stardog-test
+    volumes:
+      - /stardog
+    ports:
+      - "5821:5820"
+      - "8081:80"
+
   phpserver:
     build: ./docker/php
     image: ontowiki-devenv/phpserver
@@ -59,10 +77,11 @@ services:
     links:
       - virtuoso-dev
       - mysql-dev
+      - stardog-dev
 
   nginx:
     build: ./docker/nginx
-    image: ontowiki-devenv/nginx2
+    image: ontowiki-devenv/nginx
     container_name: ontowiki-devenv-nginx
     volumes:
       - ./..:/var/www

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,8 +1,11 @@
 FROM ubuntu:14.04
 
 RUN apt-get update \
- && apt-get install -y libvirtodbc0 raptor-utils \
- && apt-get install -y php5-fpm php5-cli php5-mysql php5-odbc php5-xdebug \
+ && apt-get install -y software-properties-common \
+ && add-apt-repository ppa:costamagnagianfranco/ettercap-stable-backports \
+ && apt-get update \
+ && apt-get install -y libvirtodbc0 raptor-utils curl \
+ && apt-get install -y php5-fpm php5-cli php5-mysql php5-odbc php5-xdebug php5-curl \
  && apt-get install -y php5-common php5-tidy php5-xsl php5-xmlrpc php5-gd php5-memcache php5-memcached \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- add stardog-dev and stardog-test to docker-compose file
- update php Dockerfile to install custom curl version (default 14.04 curl seems to have a bug, such that stardog backend has problems)
- update config templates for stardog support
- update make commands, add support for stardog
- docker run commans only need the --net parameter
- update README to use shorter docker commands, add stardog doc

You might need to rebuild the phpserver image.
